### PR TITLE
Fix example code for columns in beamer theme manual

### DIFF
--- a/latex/beamer/themes/ulund/manualulund.tex
+++ b/latex/beamer/themes/ulund/manualulund.tex
@@ -387,10 +387,10 @@ Below follows:
   \begin{column}{0.3\textwidth}
     \columnpicture{titlepictureGroup}
   \end{column}
+  \begin{column}{0.65\textwidth}
+  	[Text]
+  \end{column}
 \end{columns}%
-\begin{column}{0.65\textwidth}
-  [Text]
-\end{column}
 \end{CodeBox}      
       A picture like this is just for decoration. Important pictures should be included the normal way.
     \end{column}


### PR DESCRIPTION
`column` environment should be inside `columns` environment in example codebox.