### PR TITLE
Hide LU foot-note logo on the title page.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,6 @@ all: install
 
 .PHONY: install
 install:
-	mkdir --parents $(TEXMF)/tex/latex/beamer
+	mkdir -p $(TEXMF)/tex/latex/beamer
 	cp -r $(ROOT_DIR)/latex/ulundletter/ $(TEXMF)/tex/latex/
 	cp -r $(ROOT_DIR)/latex/beamer/ $(TEXMF)/tex/latex/beamer

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+TEXMF    := $(shell kpsewhich -var-value=TEXMFHOME)
+
+.PHONY: all
+all: install
+
+.PHONY: install
+install:
+	mkdir --parents $(TEXMF)/tex/latex/beamer
+	cp -r $(ROOT_DIR)/latex/ulundletter/ $(TEXMF)/tex/latex/
+	cp -r $(ROOT_DIR)/latex/beamer/ $(TEXMF)/tex/latex/beamer

--- a/latex/beamer/themes/ulund/beamerinnerthemeulund.sty
+++ b/latex/beamer/themes/ulund/beamerinnerthemeulund.sty
@@ -117,8 +117,10 @@
   \ifulund@printlogo
   \begin{tikzpicture}
     \useasboundingbox (0,0) rectangle (\paperwidth,\paperheight);
+    \ifnum\thepage>1\relax%
     \node[anchor=south east,inner sep=0pt] at (\paperwidth-5mm,4mm){%
       \includegraphics[height=13mm]{\ulund@logopath}};
+    \fi
   \end{tikzpicture}
   \fi
 }

--- a/latex/beamer/themes/ulund/beamerinnerthemeulund.sty
+++ b/latex/beamer/themes/ulund/beamerinnerthemeulund.sty
@@ -88,7 +88,7 @@
         \node[anchor=south west,inner sep=0pt] at (lowerleft) {%
           \includegraphics[height=\dimexpr\paperheight-2\titleimagemargin\relax]{%
             Pictures/titlepictureLU\titleimage@color}};
-        \node[anchor=north west,inner sep=0pt] at ($(upperleft)+(0.4,-0.2)+(\ulund@displaylogoxshift pt,\ulund@displaylogoyshift pt)$) {%
+        \node[anchor=north west,inner sep=0pt] at ($(upperleft)+(0.4,-0.8)+(\ulund@displaylogoxshift pt,\ulund@displaylogoyshift pt)$) {%
           \includegraphics[height=\ulund@displaylogoheight pt]{\ulund@displaylogopath}};%%%%%%%%%%%%%%%%%%%%%
       }\else{% 
         \node[anchor=south west,inner sep=0pt] at (lowerleft) {%


### PR DESCRIPTION
Hello,

I noticed that the LU logo was still visible on the title page, despite being mostly hidden by the LU sigil. This change fixes that.