### PR TITLE
Left and Right Logos in the Footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,63 @@
-# templates
-Lund University templates for documents and projects.
+# LU and LTH LaTeX Templates
+
+Collection of Lund University and Technical Faculty LaTeX templates for
+documents and projects.
+
+This repository currently contains an extensible Beamer template (`ulund`) and
+simple LaTeX letter format (`ulundletter`). More templates may be added in the
+future.
+
+
+## Official LU Fonts
+
+The beamer theme in this repository have support for the fonts ("Adobe Garamond
+Pro" and "Frutiger LT Std") used by the official Lund University graphical
+profile using the beamer option:
+
+```
+defaultfont=lu,      % [palatino], beamer, lu
+```
+
+However, using this options will only work with `lualatex` and requires a bit
+setup to work, or you may encounter the following issues:
+
+```
+XeLaTeX:
+/home/gustaf/.local/share/texlive/texmf/tex/latex/beamer/beamer/themes/ulund/beamerfontthemeulund.sty:42: Package fontspec Error: The font "AGaramondPro-Regular" cannot be found.
+
+LuaLaTeX:
+</usr/share/texmf/fonts/opentype/public/lm/lmmono10-regular.otf></home/gustaf/.local/share/fonts/FrutigerLTStd-LightItalic.otf>{/usr/share/texlive/texmf-dist/fonts/enc/dvips/ly1/texnansi.enc}</home/gustaf/.local/share/fonts/AGaramondPro-Italic.otf></usr/share/texmf/fonts/opentype/public/lm/lmmono9-regular.otf></home/gustaf/.local/share/fonts/FrutigerLTStd-Light.otf></home/gustaf/.local/share/fonts/AGaramondPro-Regular.otf></usr/share/texlive/texmf-dist/fonts/type1/public/mathdesign/mdugm/md-gmr7t.pfb></usr/share/texlive/texmf-dist/fonts/type1/public/mathdesign/mdugm/md-gmr7v.pfb></usr/share/texlive/texmf-dist/fonts/type1/public/mathdesign/mdugm/md-gmr7y.pfb></usr/share/texlive/texmf-dist/fonts/type1/public/mathdesign/mdugm/md-gmri7m.pfb>
+! error:  (type 1): cannot open file for reading 'ugmr8a.pfb'
+!  ==> Fatal error occurred, no output PDF file produced!
+```
+
+To fix this, you need to install font support files for these fonts as described
+here: https://tug.org/fonts/getnonfreefonts/ in short, you need to run the
+following commands to properly setup you TeX system:
+
+```
+curl --remote-name https://www.tug.org/fonts/getnonfreefonts/install-getnonfreefonts
+sudo texlua install-getnonfreefonts
+sudo getnonfreefonts --sys \
+     arial-urw \
+     classico \
+     dayroman \
+     gandhi \
+     garamond \
+     garamondx \
+     lettergothic \
+     literaturnaya \
+     luximono \
+     vntex-nonfree \
+     webomints
+```
+
+### Missing Characters
+
+Unfortunately, even the LU official fonts are missing some special characters,
+most notably various accented characters such as ě. One way to ameliorate this
+is to add fallback characters with the following LaTeX macros:
+
+```
+\newunicodechar{ě}{e}
+```

--- a/latex/beamer/themes/ulund/beamerinnerthemeulund.sty
+++ b/latex/beamer/themes/ulund/beamerinnerthemeulund.sty
@@ -20,14 +20,20 @@
 \DeclareOptionBeamer{titleimagemargin}{\titleimagemargin=#1}% Distance, recommended less than 2mm [default=2mm]
 %% Print logo in foot
 \newif\ifulund@printlogo\ulund@printlogotrue%% Default with logo in foot
-\def\ulund@footlineind{10mm}
-\DeclareOptionBeamer{footlogo}[true]{\csname ulund@printlogo#1\endcsname%
-  \ifulund@printlogo
-  \def\ulund@footlineind{10mm}
+\DeclareOptionBeamer{footlogo}[true]{\csname ulund@printlogo#1\endcsname}
+\newif\ifulund@leftfootlogo\ulund@leftfootlogofalse
+\DeclareOptionBeamer{useleftfootlogo}[true]{\csname ulund@leftfootlogo#1\endcsname}
+
+\DeclareOptionBeamer{leftfootlogo}{%
+  \ifulund@leftfootlogo
+  \def\ulund@leftlogopath{#1}
   \else
-  \def\ulund@footlineind{0mm}
-  \fi%
+  \def\ulund@leftlogopath{Pictures/lulogo-en}
+  \fi
 }
+
+
+
 %% English logo
 \newif\ifulund@english\ulund@englishtrue%% Default English
 \DeclareOptionBeamer{english}[true]{\csname ulund@english#1\endcsname}
@@ -114,15 +120,21 @@
 }
 
 \setbeamertemplate{background}{%
-  \ifulund@printlogo
   \begin{tikzpicture}
-    \useasboundingbox (0,0) rectangle (\paperwidth,\paperheight);
     \ifnum\thepage>1\relax%
-    \node[anchor=south east,inner sep=0pt] at (\paperwidth-5mm,4mm){%
-      \includegraphics[height=13mm]{\ulund@logopath}};
+      \ifulund@printlogo
+        \useasboundingbox (0,0) rectangle (\paperwidth,\paperheight);
+        \node[anchor=south east,inner sep=0pt] at ($(current page.south east)+(-3.5mm,2mm)$) {%
+          \includegraphics[height=13mm]{\ulund@logopath}
+        };
+      \fi
+      \ifulund@leftfootlogo
+        \node[anchor=south west,inner sep=0pt] at ($(current page.south west)+(3.5mm,2mm)$) {%
+          \includegraphics[height=13mm]{\ulund@leftlogopath}
+        };
+      \fi
     \fi
   \end{tikzpicture}
-  \fi
 }
 
 %%%% Items and stuff

--- a/latex/beamer/themes/ulund/beamerinnerthemeulund.sty
+++ b/latex/beamer/themes/ulund/beamerinnerthemeulund.sty
@@ -18,9 +18,9 @@
 \titleimagecolor{gray}
 \DeclareOptionBeamer{titleimagecolor}{\titleimagecolor{#1}}% blue,darkgray,gray,green,red
 \DeclareOptionBeamer{titleimagemargin}{\titleimagemargin=#1}% Distance, recommended less than 2mm [default=2mm]
+
+
 %% Print logo in foot
-\newif\ifulund@printlogo\ulund@printlogotrue%% Default with logo in foot
-\DeclareOptionBeamer{footlogo}[true]{\csname ulund@printlogo#1\endcsname}
 \newif\ifulund@leftfootlogo\ulund@leftfootlogofalse
 \DeclareOptionBeamer{useleftfootlogo}[true]{\csname ulund@leftfootlogo#1\endcsname}
 
@@ -28,11 +28,24 @@
   \ifulund@leftfootlogo
   \def\ulund@leftlogopath{#1}
   \else
-  \def\ulund@leftlogopath{Pictures/lulogo-en}
+  \def\ulund@leftlogopath{Pictures/lugogo-sv}
   \fi
 }
 
+\newif\ifulund@rightfootlogo\ulund@rightfootlogofalse
+\DeclareOptionBeamer{userightfootlogo}[true]{\csname ulund@rightfootlogo#1\endcsname}
 
+\DeclareOptionBeamer{rightfootlogo}{%
+  \ifulund@rightfootlogo
+  \def\ulund@rightlogopath{#1}
+  \else
+  \def\ulund@rightlogopath{Pictures/lulogo-en}
+  \fi
+}
+
+%% Footer logo
+\newif\ifulund@printlogo\ulund@printlogotrue %% Defaults to logo in foot.
+\DeclareOptionBeamer{footlogo}[true]{\csname ulund@printlogo#1\endcsname}
 
 %% English logo
 \newif\ifulund@english\ulund@englishtrue%% Default English
@@ -46,7 +59,6 @@
 
 %%%%%%%%% Set the path to logo
 \ifulund@english
-  \def\ulund@logopath{Pictures/lulogo-en}
   \ifulund@LTHlogo
     \def\ulund@displaylogopath{Pictures/LTH_Logo_en}
     \def\ulund@displaylogoheight{60}
@@ -61,7 +73,6 @@
     \def\ulund@displaylogoscale{0.75}
   \fi
 \else
-  \def\ulund@logopath{Pictures/lulogo-sv}
   \ifulund@LTHlogo
     \def\ulund@displaylogopath{Pictures/LTH_Logotyp_sv}
     \def\ulund@displaylogoheight{96}
@@ -75,8 +86,22 @@
     \def\ulund@displaylogoyshift{0}
     \def\ulund@displaylogoscale{0.75}
   \fi
-\fi  
+\fi
 
+
+%% Set Paths for the footer logo to be backwards compatible.
+\ifulund@rightfootlogo
+  % Do nothing: We assume a logo has been set.
+\else
+  \ifulund@english
+    \def\ulund@rightlogopath{Pictures/lulogo-en}
+  \else
+    \def\ulund@rightlogopath{Pictures/lulogo-sv}
+  \fi
+  \ifulund@printlogo
+    \newif\ifulund@rightfootlogo\ulund@rightfootlogotrue
+  \fi
+\fi
 
 
 %%%%%%%%
@@ -122,10 +147,10 @@
 \setbeamertemplate{background}{%
   \begin{tikzpicture}
     \ifnum\thepage>1\relax%
-      \ifulund@printlogo
+      \ifulund@rightfootlogo
         \useasboundingbox (0,0) rectangle (\paperwidth,\paperheight);
         \node[anchor=south east,inner sep=0pt] at ($(current page.south east)+(-3.5mm,2mm)$) {%
-          \includegraphics[height=13mm]{\ulund@logopath}
+          \includegraphics[height=13mm]{\ulund@rightlogopath}
         };
       \fi
       \ifulund@leftfootlogo

--- a/latex/beamer/themes/ulund/beamerouterthemeulund.sty
+++ b/latex/beamer/themes/ulund/beamerouterthemeulund.sty
@@ -95,24 +95,33 @@
 %% Foot
 \setbeamertemplate{footline}[text line]{%
   \begin{beamercolorbox}[wd=\dimexpr\textwidth-10mm\relax,ht=24pt]{text in head/foot}
-    \begin{tikzpicture}[x={\textwidth-\ulund@footlineind},y=24pt]
-      \useasboundingbox (0,0) rectangle (1,1);
+    \begin{tikzpicture}[y=24pt]
+      \tikzmath{ let \boff = 0mm; let \foff = 0mm; }
+      \ifulund@printlogo
+        \tikzmath{ let \foff = 8mm; }
+      \fi
+      \ifulund@leftfootlogo
+        \tikzmath{ let \boff = 8mm; }
+      \fi
+      \tikzmath{ let \bx = \boff; let \fx = \textwidth - \foff; }
+
+      \useasboundingbox (0, 0) rectangle (1, 1);
       \ifulund@foot{%
-        %\fill[white] (0,0) rectangle (1,1);
-        \draw[thin,color=lundbronze] (0,1)--(1,1);
-        \node[anchor=north west,inner sep=0pt] at (0,0.8){\ulund@foot@left};
-        \node[anchor=north,inner sep=0pt] at (0.5,0.8){\ulund@foot@mid};
-        \node[anchor=north east,inner sep=0pt] at (1,0.8){\ulund@foot@right};
+        % \fill[black] (0,0) rectangle (1,1);
+        \draw[thin,color=lundbronze] (\bx, 1) -- (\fx, 1);
+        \node[anchor=north west,inner sep=0pt] (a) at (\bx,0.8){\ulund@foot@left};
+        \node[anchor=north east,inner sep=0pt] (b) at (\fx,0.8){\ulund@foot@right};
+        \node[anchor=north,     inner sep=0pt] (c) at ($(a)!0.5!(b)$){\ulund@foot@mid};
       }
       \else{%
         \ifulund@nofootslidenum{%
-          \node[anchor=north east,inner sep=0pt] at (1,0.8){\ulund@foot@right};
+          \node[anchor=north east,inner sep=0pt] at (1.0\fx,0.8){\ulund@foot@right};
         }
         \fi
       }
       \fi
       \ifulund@navigationsymbols% Navigation symbols (independent of footbox)
-      \node[anchor=south east,inner sep=0pt,yshift=2pt] at (1,0){\ulund@foot@navigationsymbols};
+      \node[anchor=south east,inner sep=0pt,yshift=2pt] at (1.0\fx,0){\ulund@foot@navigationsymbols};
       \fi
     \end{tikzpicture}
   \end{beamercolorbox}

--- a/latex/beamer/themes/ulund/beamerouterthemeulund.sty
+++ b/latex/beamer/themes/ulund/beamerouterthemeulund.sty
@@ -97,7 +97,7 @@
   \begin{beamercolorbox}[wd=\dimexpr\textwidth-10mm\relax,ht=24pt]{text in head/foot}
     \begin{tikzpicture}[y=24pt]
       \tikzmath{ let \boff = 0mm; let \foff = 0mm; }
-      \ifulund@printlogo
+      \ifulund@rightfootlogo
         \tikzmath{ let \foff = 8mm; }
       \fi
       \ifulund@leftfootlogo

--- a/latex/beamer/themes/ulund/beamerthemeulund.sty
+++ b/latex/beamer/themes/ulund/beamerthemeulund.sty
@@ -23,6 +23,14 @@
   \PassOptionsToPackage{LTHlogo=#1}{beamerinnerthemeulund}
 }
 
+\DeclareOptionBeamer{useleftfootlogo}[false]{%
+  \PassOptionsToPackage{useleftfootlogo=#1}{beamerinnerthemeulund}
+}
+\DeclareOptionBeamer{leftfootlogo}{%
+  \PassOptionsToPackage{leftfootlogo=#1}{beamerinnerthemeulund}
+}
+
+
 %%%%%%%%%%%%%%%%%%%%%%%%%% Outer related
 %% navigation symbols
 \DeclareOptionBeamer{navigationsymbols}[true]{%
@@ -67,7 +75,7 @@
 %\PassOptionsToPackage{cmyk}{xcolor}% Not needed, ok with cmyk anyway.
 \RequirePackage{tikz}
 \graphicspath{{./Pictures/}}
-\usetikzlibrary{calc,positioning}
+\usetikzlibrary{calc,math,positioning}
 \RequirePackage{relsize}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%% Call the other beamer packages

--- a/latex/beamer/themes/ulund/beamerthemeulund.sty
+++ b/latex/beamer/themes/ulund/beamerthemeulund.sty
@@ -30,6 +30,13 @@
   \PassOptionsToPackage{leftfootlogo=#1}{beamerinnerthemeulund}
 }
 
+\DeclareOptionBeamer{userightfootlogo}[false]{%
+  \PassOptionsToPackage{userightfootlogo=#1}{beamerinnerthemeulund}
+}
+\DeclareOptionBeamer{rightfootlogo}{%
+  \PassOptionsToPackage{rightfootlogo=#1}{beamerinnerthemeulund}
+}
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%% Outer related
 %% navigation symbols

--- a/latex/beamer/themes/ulund/manualulund.tex
+++ b/latex/beamer/themes/ulund/manualulund.tex
@@ -23,6 +23,10 @@
 % blackitemmark=false,       % true   / [false]  Black item marks, o.w. Lund bronze
 % defaultfont=palatino,      % [palatino], beamer, lu
 % sectionframe=true,
+% useleftfootlogo=true,              % true / [false]
+% leftfootlogo=Pictures/lulogo-en,   % No default.
+% userightfootlogo=true,             % true / [false]
+% rightfootlogo=Pictures/lulogo-sv,  % No default.
 ]{ulund}
 %%%%%%%%%%%%%%%%%%%%% Layout commands 
 %%%% Foot
@@ -267,8 +271,6 @@ Also, see the \texttt{defaultfont} option described below to see important infor
   \item Command \verb|\sectionimage{}| to put optional image on section slide. Or use the same as set by \verb|\titleimage|.
   \item Background image on slides.
   \item Options for header line.
-  \item Options for other faculties than LTH. Is there a demand for it? (The code for choosing logo has to be rewritten).
-  \item Command for second logo. (This is not obvious how to include)
   \item Command to change options on the run.
   \end{itemize}
   Questions, comments and suggestions: \verb|stefan.host@eit.lth.se|


### PR DESCRIPTION
I recently added support for setting custom logos to the left and right of the footer. This makes it a bit easier to display dual affiliations such as I did recently for my presentation at the High-Performance Graphics conference: https://www.youtube.com/watch?v=9jL1t-gsENY

Or which can be seen here: https://gustafwaldemarson.com/misc/hpg24/compress-paper-beamer_w_notes.pdf (Note: this is a temporary link!)

These options are exposed through the new lubeamer options:

```
useleftfootlogo=true,              % true / [false]
leftfootlogo=Pictures/lulogo-en,   % No default.
userightfootlogo=true,             % true / [false]
rightfootlogo=Pictures/lulogo-sv,  % No default.
```

The value for the logos `rightfootlogo` and `leftfootlogo` can now be set to any image file. See the `manualulund.tex` file for examples on how these can be used. Note that they are not activated without the corresponding `userightfootlogo` and `useleftfootlogo` options.

I also made sure that these changes are *mostly* backwards compatible. I.e., if you use the now old `footlogo` option, it should still work as before. The new options take precedence however should both of them be used.

The README has now also been updated to address issue #5 