### PR TITLE
Avoid footnotes from clipping footer logos.

### DIFF
--- a/latex/beamer/themes/ulund/beamerinnerthemeulund.sty
+++ b/latex/beamer/themes/ulund/beamerinnerthemeulund.sty
@@ -172,5 +172,12 @@
 \setbeamertemplate{enumerate subitems}[default]
 \setbeamertemplate{enumerate subsubitems}[default]
 
-
-
+% Center footnotes to avoid clipping the left and/or right footer logos.
+\setbeamertemplate{footnote}{%
+  \hspace*{\fill}%
+  \begin{minipage}{0.875\textwidth}%
+    \parindent1em\noindent%
+    \noindent\insertfootnotemark\insertfootnotetext\\%
+  \end{minipage}%
+  \hspace*{\fill}%
+}%

--- a/latex/beamer/themes/ulund/manualulund.tex
+++ b/latex/beamer/themes/ulund/manualulund.tex
@@ -455,6 +455,19 @@ Also, see the \texttt{defaultfont} option described below to see important infor
 \end{frame}
 
 %%%%%%%%%%%%%%%
+\begin{frame}[fragile]
+  \frametitle{Slide Footnotes}
+
+  \begin{itemize}
+  \item This is a footnote example.\footnote{This is an example of a slightly
+      longer footnote, which we obviously do not want to clip with the left or
+      right footer logos.}
+  \end{itemize}
+
+\end{frame}
+
+
+%%%%%%%%%%%%%%%
 \begin{frame}[fragile,fragile]
   \frametitle{End page}
   Finally, the end of the presentation should state where you are from:


### PR DESCRIPTION
Footnote fix for issue #7.