### PR TITLE
Two small footer fixes

### DIFF
--- a/latex/beamer/themes/ulund/beamerinnerthemeulund.sty
+++ b/latex/beamer/themes/ulund/beamerinnerthemeulund.sty
@@ -144,6 +144,9 @@
   \addtocounter{framenumber}{-1}
 }
 
+% Adjust \maketitle to use the plain style for the frame
+\def\maketitle{\ifbeamer@inframe\titlepage\else\frame[plain]{\titlepage}\fi}
+
 \setbeamertemplate{background}{%
   \begin{tikzpicture}
     \ifnum\thepage>1\relax%

--- a/latex/beamer/themes/ulund/beamerouterthemeulund.sty
+++ b/latex/beamer/themes/ulund/beamerouterthemeulund.sty
@@ -111,7 +111,7 @@
         \draw[thin,color=lundbronze] (\bx, 1) -- (\fx, 1);
         \node[anchor=north west,inner sep=0pt] (a) at (\bx,0.8){\ulund@foot@left};
         \node[anchor=north east,inner sep=0pt] (b) at (\fx,0.8){\ulund@foot@right};
-        \node[anchor=north,     inner sep=0pt] (c) at ($(a)!0.5!(b)$){\ulund@foot@mid};
+        \node[anchor=center,    inner sep=0pt] (c) at ($(a)!0.5!(b)$){\ulund@foot@mid};
       }
       \else{%
         \ifulund@nofootslidenum{%


### PR DESCRIPTION
I noticed two minor annoyances with the footer:

1. The center text (the title of the presentation) is not vertically aligned with the page number and author name. This is more obvious when using more square aspect ratios, but look a bit odd for all sizes.
2. When using only the theme and not the template, I made the mistake of using `\maketitle`, which breaks the title frame by including the footer. I suspect other users might make the same mistake in the future.

I have provided fixes for both problems.
The second problem is fixed by redefining the `\maketitle` command in the inner theme.
I use the same [definition as in the beamer package](https://mirrors.ctan.org/macros/latex/contrib/beamer/base/beamerbasetitle.sty), except with an added `[plain]`.